### PR TITLE
googleapps-grant-access 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# googleapps-grant-access [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/googleapps-grant-access.svg)](https://www.npmjs.com/package/googleapps-grant-access) [![Downloads](https://img.shields.io/npm/dt/googleapps-grant-access.svg)](https://www.npmjs.com/package/googleapps-grant-access) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# googleapps-grant-access
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/googleapps-grant-access.svg)](https://www.npmjs.com/package/googleapps-grant-access) [![Downloads](https://img.shields.io/npm/dt/googleapps-grant-access.svg)](https://www.npmjs.com/package/googleapps-grant-access) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Grant access to Google applications
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googleapps-grant-access",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Grant access to Google applications",
   "main": "index.js",
   "scripts": {
@@ -30,6 +30,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
